### PR TITLE
usafacts fix

### DIFF
--- a/usafacts/delphi_usafacts/pull.py
+++ b/usafacts/delphi_usafacts/pull.py
@@ -177,6 +177,7 @@ def pull_usafacts_data(base_url: str, metric: str, logger: Logger, cache: str=No
     if len(missing_dates) > 0:
         padding = pd.DataFrame(list(product(df['fips'].unique(), missing_dates, [np.nan], [np.nan])), columns=['fips', 'timestamp', 'cumulative_counts', 'new_counts'])
         df = pd.concat([df, padding], ignore_index=True).sort_values(['fips', 'timestamp'])
+        assert df[df['timestamp'].isin(missing_dates)][['cumulative_counts', 'new_counts']].isna().all().all() == True
     ################### FIX ###################
 
     unique_days = df["timestamp"].unique()


### PR DESCRIPTION
### Error Identification
The error is caused when some dates are missing between the minimum and maximum dates in the dataframe.

### Error Message Improvement
We can improve the error message by listing the ranges in which dates are missing. This keeps the error message concise and informative, instead of listing every single missing date.

### Error Correction
Even if we include these missing dates in the dataframe, we need to be mindful of what we set the `counts` columns to. Since no data is available, it would be disingenuous to set them to zero. However, in `run.py`, we can see that for the smoothing and other modules, there is an imputation module for NaNs. Since `run.py` can handle NaNs, we just include these missing dates with NaN count values.
